### PR TITLE
imp: make extensions optional partial configs

### DIFF
--- a/extensions/default.nix
+++ b/extensions/default.nix
@@ -1,6 +1,7 @@
-{ pkgs, engines }:
+{ pkgs, engines, data-merge }:
 with pkgs.lib;
 let
+
   # Build a list of all local directory names (same as extension name)
   exts = builtins.attrNames
     (filterAttrs (n: v: v == "directory") (builtins.readDir ./.));
@@ -8,10 +9,23 @@ let
   # Create a list of extension name => import for each extension
   extList = builtins.map
     (p: {
-      "${p}" = import
-        (builtins.toPath ./. + "/${p}")
-        { inherit pkgs engines; };
+      "${p}" =
+        let
+          ext = import (builtins.toPath ./. + "/${p}") { inherit pkgs engines; };
+        in
+        {
+          # Implement as functor to allow downstream users
+          # to cleanly extend // override a partial config
+          # Store args in a transparent accumulator
+          __args = { };
+          __functor = self: args:
+            let
+              # Implement with `data-merge` to handle list merging appropriately
+              __args = data-merge.merge self.__args args;
+            in
+            self // (ext __args) // { inherit __args; };
+        };
     })
     exts;
 in
-fold (x: y: pkgs.lib.recursiveUpdate x y) { } extList
+fold pkgs.lib.recursiveUpdate { } extList

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,24 @@
 {
   "nodes": {
+    "data-merge": {
+      "inputs": {
+        "nixlib": "nixlib",
+        "yants": "yants"
+      },
+      "locked": {
+        "lastModified": 1648237091,
+        "narHash": "sha256-OtgcOt/CB0/9S0rh1eAog+AvAg9kF6GyAknyWOXiAZI=",
+        "owner": "divnix",
+        "repo": "data-merge",
+        "rev": "b21bcf7bd949ac92af3930ecb1d3df8786384722",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "data-merge",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1653893745,
@@ -30,10 +49,87 @@
         "type": "github"
       }
     },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixago": {
       "inputs": {
         "flake-utils": "flake-utils_2",
+        "nixago-exts": "nixago-exts",
         "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1655699216,
+        "narHash": "sha256-NSSTNUz0TyH/RyQZ+ZdBa1PHl7klWcSGfffoaAN7BBA=",
+        "owner": "nix-community",
+        "repo": "nixago",
+        "rev": "1640dd9bc8246b5ef23664b5160a1b7a5b4cf57c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixago",
+        "type": "github"
+      }
+    },
+    "nixago-exts": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixago": "nixago_2",
+        "nixpkgs": [
+          "nixago",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1655508669,
+        "narHash": "sha256-BDDdo5dZQMmwNH/GNacy33nPBnCpSIydWFPZs0kkj/g=",
+        "owner": "nix-community",
+        "repo": "nixago-extensions",
+        "rev": "3022a932ce109258482ecc6568c163e8d0b426aa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixago-extensions",
+        "type": "github"
+      }
+    },
+    "nixago_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": [
+          "nixago",
+          "nixago-exts",
           "nixpkgs"
         ]
       },
@@ -51,7 +147,37 @@
         "type": "github"
       }
     },
+    "nixlib": {
+      "locked": {
+        "lastModified": 1655599917,
+        "narHash": "sha256-kjZbt5WdTrnjMxL79okg9TCoRUdADG50x/TWozbyTsE=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "5fb55578aa2f1a502d636a8ac71aece57cb730bb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1655599917,
+        "narHash": "sha256-kjZbt5WdTrnjMxL79okg9TCoRUdADG50x/TWozbyTsE=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "5fb55578aa2f1a502d636a8ac71aece57cb730bb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1655403069,
         "narHash": "sha256-KgSt10yK5ZmUWXNFiqJaSQq1lw2SA5Lt6nb6dr4oh0A=",
@@ -68,9 +194,28 @@
     },
     "root": {
       "inputs": {
+        "data-merge": "data-merge",
         "flake-utils": "flake-utils",
         "nixago": "nixago",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "yants": {
+      "inputs": {
         "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1645126146,
+        "narHash": "sha256-XQ1eg4gzXoc7Tl8iXak1uCt3KnsTyxqPtLE+vOoDnrQ=",
+        "owner": "divnix",
+        "repo": "yants",
+        "rev": "77df2be1b3cce9f571c6cf451f786b266a6869cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "yants",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,11 +2,12 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
+    data-merge.url = "github:divnix/data-merge";
     nixago.url = "github:nix-community/nixago";
     nixago.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, flake-utils, nixago }:
+  outputs = { self, nixpkgs, flake-utils, nixago, data-merge }:
     rec {
       # Only run CI on Linux
       herculesCI.ciSystems = [ "x86_64-linux" "aarch64-linux" ];
@@ -15,7 +16,7 @@
         let
           engines = nixago.engines.${system};
           make = nixago.lib.${system}.make;
-          exts = import ./extensions { inherit pkgs engines; };
+          exts = import ./extensions { inherit pkgs engines data-merge; };
 
           # Setup pkgs
           pkgs = import nixpkgs {
@@ -61,6 +62,6 @@
               packages = tools.all;
             };
           };
-        } // import ./extensions { inherit pkgs engines; }
+        } // import ./extensions { inherit pkgs engines data-merge; }
       ));
 }


### PR DESCRIPTION
- use `data-merge` to enforce defined behaviour on merging lists
- `__functor` renders the configuration an optional partial
- `__args` accumulates the arguments over each variadic functor
  invocation - lazyness ensures only the final attrs evaluates

Example usage:
https://github.com/input-output-hk/nixagii/blob/73ccbf3f90114d6e4c6bb4950bb971d0fd215695/flake.nix#L110-L114