### PR TITLE
Replace deprecated fold with foldr + run just fmt

### DIFF
--- a/extensions/default.nix
+++ b/extensions/default.nix
@@ -19,4 +19,4 @@ with pkgs.lib; let
     })
     exts;
 in
-  fold (x: y: pkgs.lib.recursiveUpdate x y) {} extList
+  foldr (x: y: pkgs.lib.recursiveUpdate x y) {} extList

--- a/extensions/default.nix
+++ b/extensions/default.nix
@@ -1,17 +1,22 @@
-{ pkgs, engines }:
-with pkgs.lib;
-let
+{
+  pkgs,
+  engines,
+}:
+with pkgs.lib; let
   # Build a list of all local directory names (same as extension name)
-  exts = builtins.attrNames
+  exts =
+    builtins.attrNames
     (filterAttrs (n: v: v == "directory") (builtins.readDir ./.));
 
   # Create a list of extension name => import for each extension
-  extList = builtins.map
+  extList =
+    builtins.map
     (p: {
-      "${p}" = import
+      "${p}" =
+        import
         (builtins.toPath ./. + "/${p}")
-        { inherit pkgs engines; };
+        {inherit pkgs engines;};
     })
     exts;
 in
-fold (x: y: pkgs.lib.recursiveUpdate x y) { } extList
+  fold (x: y: pkgs.lib.recursiveUpdate x y) {} extList

--- a/tests/common.nix
+++ b/tests/common.nix
@@ -1,17 +1,25 @@
-/* Common test runner used across all tests
-*/
-{ pkgs, make, exts }:
-{ name, input, expected }:
-let
+/*
+ Common test runner used across all tests
+ */
+{
+  pkgs,
+  make,
+  exts,
+}: {
+  name,
+  input,
+  expected,
+}: let
   # Call make
   result = make (exts.${name} input);
 
   # Compare the result from make with the expected result
-  der = pkgs.runCommand "test.${name}"
-    { }
+  der =
+    pkgs.runCommand "test.${name}"
+    {}
     ''
       cmp "${expected}" "${result.configFile}"
       touch $out
     '';
 in
-der
+  der

--- a/tests/conform/default.nix
+++ b/tests/conform/default.nix
@@ -1,5 +1,4 @@
-{ runTest }:
-let
+{runTest}: let
   name = "conform";
   expected = ./expected.yml;
   input = {
@@ -34,6 +33,6 @@ let
     };
   };
 in
-runTest {
-  inherit input expected name;
-}
+  runTest {
+    inherit input expected name;
+  }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,24 +1,28 @@
-{ pkgs, runTest }:
-with pkgs.lib;
-let
+{
+  pkgs,
+  runTest,
+}:
+with pkgs.lib; let
   # Add tests to skip
-  skipTests = [ ];
+  skipTests = [];
 
   # Build a list of all local directory names (test names)
-  tests = builtins.attrNames
+  tests =
+    builtins.attrNames
     (filterAttrs (n: v: v == "directory") (builtins.readDir ./.));
 
   # Create a list of testName => import for each test
-  testsList = builtins.map
+  testsList =
+    builtins.map
     (p: {
-      "${p}" = import (builtins.toPath ./. + "/${p}") { inherit runTest; };
+      "${p}" = import (builtins.toPath ./. + "/${p}") {inherit runTest;};
     })
     tests;
 
   # Fold the list back into a single set
-  testsAttrs = fold (x: y: recursiveUpdate x y) { } testsList;
+  testsAttrs = fold (x: y: recursiveUpdate x y) {} testsList;
 
   # Remove skipped tests
   allTests = builtins.removeAttrs testsAttrs skipTests;
 in
-allTests
+  allTests

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -20,7 +20,7 @@ with pkgs.lib; let
     tests;
 
   # Fold the list back into a single set
-  testsAttrs = fold (x: y: recursiveUpdate x y) {} testsList;
+  testsAttrs = foldr (x: y: recursiveUpdate x y) {} testsList;
 
   # Remove skipped tests
   allTests = builtins.removeAttrs testsAttrs skipTests;

--- a/tests/ghsettings/default.nix
+++ b/tests/ghsettings/default.nix
@@ -1,5 +1,4 @@
-{ runTest }:
-let
+{runTest}: let
   name = "ghsettings";
   expected = ./expected.yml;
   input = {
@@ -30,6 +29,6 @@ let
     ];
   };
 in
-runTest {
-  inherit input expected name;
-}
+  runTest {
+    inherit input expected name;
+  }

--- a/tests/just/default.nix
+++ b/tests/just/default.nix
@@ -1,5 +1,4 @@
-{ runTest }:
-let
+{runTest}: let
   name = "just";
   expected = ./expected.txt;
   input = {
@@ -14,6 +13,6 @@ let
     };
   };
 in
-runTest {
-  inherit input expected name;
-}
+  runTest {
+    inherit input expected name;
+  }

--- a/tests/lefthook/default.nix
+++ b/tests/lefthook/default.nix
@@ -1,11 +1,10 @@
-{ runTest }:
-let
+{runTest}: let
   name = "lefthook";
   expected = ./expected.yml;
   input = {
     commit-msg = {
       scripts = {
-        template_checker = { runner = "bash"; };
+        template_checker = {runner = "bash";};
       };
     };
     pre-commit = {
@@ -23,11 +22,11 @@ let
         };
       };
       scripts = {
-        "good_job.js" = { runner = "node"; };
+        "good_job.js" = {runner = "node";};
       };
     };
   };
 in
-runTest {
-  inherit input expected name;
-}
+  runTest {
+    inherit input expected name;
+  }

--- a/tests/pre-commit/default.nix
+++ b/tests/pre-commit/default.nix
@@ -1,5 +1,4 @@
-{ runTest }:
-let
+{runTest}: let
   name = "pre-commit";
   expected = ./expected.yml;
   input = {
@@ -10,6 +9,6 @@ let
     };
   };
 in
-runTest {
-  inherit input expected name;
-}
+  runTest {
+    inherit input expected name;
+  }


### PR DESCRIPTION
This PR fixes the usage of the deprecated builtin "fold".

### Context
The builtin fold is deprecated and should be replaced with foldr.

### What’s in this PR
Commit 1: runs just fmt to match the repository formatting rules (otherwise just check fails)
Commit 2: replaces fold with foldR

(sorry for the noice of PR #4, I've messed my remote when doing the same kind of changes in [Nixago#62](https://github.com/nix-community/nixago/pull/62))